### PR TITLE
Preserve existing classes on the active li element

### DIFF
--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -76,9 +76,9 @@
     // Highlight active link on the navigation
     var selectActiveMenuItem = function (i) {
       forEach(links, function (i, el) {
-        links[i].parentNode.className = "";
+        links[i].parentNode.className = links[i].parentNode.className.replace(/[\s]{0,}active/, '');
       });
-      links[i].parentNode.className = "active";
+      links[i].parentNode.className += links[i].parentNode.className ? " active" : "active";
     };
 
     // Highlight active link when scrolling


### PR DESCRIPTION
Instead of deleting or replacing all classes of the active element with "active", add and remove the "active" class. This way it is possible to style  some of the li elements with additional classes. In my case, this was useful when adding a separator which did not appear for all elements.
