### PR TITLE
Added navigation close on scroll

### DIFF
--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -106,6 +106,9 @@
           }
         });
       }
+      
+      // Close navigation when scrolling
+      navigation.close();
     }, false);
 
     // Close navigation when tapping the mask under it


### PR DESCRIPTION
Navigation should automatically close on scroll. 

This was tested working with the latest Microsoft Edge, Firefox, Chrome, and iOS.