### PR TITLE
fixed-nav didn't work if an ID doesn't exist

### DIFF
--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -60,8 +60,11 @@
     var setupLocations = function () {
       content = [];
       forEach(links, function (i, el) {
-        var href = links[i].getAttribute("href").replace("#", "");
-        content.push(document.getElementById(href).offsetTop + 200);
+        var id = links[i].getAttribute("href");
+        var elem = document.querySelector(id);
+        if(elem != null) {
+          content.push(elem.offsetTop + 200);
+        }
       });
     };
 


### PR DESCRIPTION
when an anchor has an href different than an id (`#id`):

```
<a href="not-an-id"></a>
```

Fixed-nav errors out, this is an attempt to ignore those routes and not to add them to the content array. This can happen when the anchor is pointing to an external resource, etc...