### PR TITLE
[bugfix] id not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ You are free to use the JavaScript, styles and the icon fonts provided here in y
 * Closes the navigation when user tap's outside of it
 * Tapping a link changes the URL, so you can still copy/paste it and link to different sections
 * Built progressive enhancement in mind
+* Allows external links
 
+##External Links
 
+To allow external links, add the attribute `data-external-link` to the anchor element and remove `data-scroll`.
+
+```
+<a href="not-an-id" data-external-link>external link</a>
+<a href="#normal-link" data-scroll>normal link</a>
+```
 
 # Live example
 

--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -60,8 +60,11 @@
     var setupLocations = function () {
       content = [];
       forEach(links, function (i, el) {
-        var href = links[i].getAttribute("href").replace("#", "");
-        content.push(document.getElementById(href).offsetTop + 200);
+        var id = links[i].getAttribute("href");
+        var elem = document.querySelector(id);
+        if(elem != null) {
+          content.push(elem.offsetTop + 200);
+        }
       });
     };
 

--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -51,7 +51,7 @@
 
     // Find navigation links and save a reference to them
     var nav = document.querySelector(".nav-collapse ul"),
-      links = nav.querySelectorAll("a");
+      links = nav.querySelectorAll("a:not([data-external-link])");
 
     // "content" will store all the location cordinates
     var content;

--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -60,11 +60,8 @@
     var setupLocations = function () {
       content = [];
       forEach(links, function (i, el) {
-        var id = links[i].getAttribute("href");
-        var elem = document.querySelector(id);
-        if(elem != null) {
-          content.push(elem.offsetTop + 200);
-        }
+        var href = links[i].getAttribute("href").replace("#", "");
+        content.push(document.getElementById(href).offsetTop + 200);
       });
     };
 


### PR DESCRIPTION
When there is an anchor element that does not contain a hash link only, fixed-nav errors out and does not work anymore.

This aim to have anchors that can point to outside resources by simply adding the attribute `data-external-link`
