### PR TITLE
[bugfix] external links were breaking menu highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
           <li class="menu-item"><a href="#about" data-scroll>About</a></li>
           <li class="menu-item"><a href="#projects" data-scroll>Projects</a></li>
           <li class="menu-item"><a href="#blog" data-scroll>Blog</a></li>
+          <li class="menu-item"><a href="http://www.google.com" target="_blank">Google</a></li>
         </ul>
       </nav>
     </header>

--- a/js/fixed-responsive-nav.js
+++ b/js/fixed-responsive-nav.js
@@ -51,7 +51,7 @@
 
     // Find navigation links and save a reference to them
     var nav = document.querySelector(".nav-collapse ul"),
-      links = nav.querySelectorAll("a");
+      links = nav.querySelectorAll("[data-scroll]");
 
     // "content" will store all the location cordinates
     var content;


### PR DESCRIPTION
Fixes issue #33 

1. External links can now be added to menu.
2. External links must **NOT** have `data-scroll`.